### PR TITLE
Fixed links to help docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ with various tools via [Go's custom command](http://support.thoughtworks.com/ent
 This Readme describes syntax of a command and the structure of the repository.
 For full documentation about Go's support for this feature, please see:
 
-<http://www.thoughtworks.com/products/docs/go/current/help/command_repository.html>
+<http://www.go.cd/documentation/user/current/advanced_usage/command_repository.html>
 
 Also check out these articles explaining how this can be used.
 

--- a/package/rpm/go-download-rpm-on-agent.xml
+++ b/package/rpm/go-download-rpm-on-agent.xml
@@ -3,7 +3,7 @@ name: Download rpm locally
 description:  Curl command to download an rpm package that was polled for by the bundled yum plugin (Go version 13.3) on an agent. The command shown uses ORA as repository name and GCC as package name. Please replace as appropriate.
 author: Go Team
 authorinfo: http://support.thoughtworks.com/categories/20002778-go-community-support
-moreinfo: http://www.thoughtworks.com/products/docs/go/current/help/yum_repository_poller.html#download
+moreinfo: http://www.go.cd/documentation/user/current/extension_points/yum_repository_poller.html#downloading-rpms
 keywords: package, rpm, yum, download
 -->
 <exec command="/bin/bash">

--- a/package/rpm/go-download-rpm-remote.xml
+++ b/package/rpm/go-download-rpm-remote.xml
@@ -3,7 +3,7 @@ name: Download rpm remotely
 description:  Curl command to download on a remote node an rpm package that was polled for by the bundled yum plugin (Go version 13.3). The command shown uses ORA as repository name and GCC as package name. Please replace as appropriate.
 author: Go Team
 authorinfo: http://support.thoughtworks.com/categories/20002778-go-community-support
-moreinfo: http://www.thoughtworks.com/products/docs/go/current/help/yum_repository_poller.html#download
+moreinfo: http://www.go.cd/documentation/user/current/extension_points/yum_repository_poller.html#downloading-rpms
 keywords: package, rpm, yum, download
 -->
 <exec command="/bin/bash">

--- a/package/rpm/go-install-independent-rpm-on-agent.xml
+++ b/package/rpm/go-install-independent-rpm-on-agent.xml
@@ -3,7 +3,7 @@ name: Install/Upgrade independent rpm on agent
 description: Install/Upgrade on agent a pre-downloaded independent rpm that is polled for by the bundled yum plugin (Go version 13.3). The command shown uses ORA as repository name and GCC as package name. Please replace as appropriate. Target node user should have passwordless sudo privilege.
 author: Go Team
 authorinfo: http://support.thoughtworks.com/categories/20002778-go-community-support
-moreinfo: http://www.thoughtworks.com/products/docs/go/current/help/yum_repository_poller.html#install
+moreinfo: http://www.go.cd/documentation/user/current/extension_points/yum_repository_poller.html#installing-rpms
 keywords: yum, install, rpm, upgrade
 -->
 <exec command="/bin/bash">

--- a/package/rpm/go-install-independent-rpm-remote.xml
+++ b/package/rpm/go-install-independent-rpm-remote.xml
@@ -3,7 +3,7 @@ name: Install/Upgrade rpm on remote node
 description: Install/Upgrade on remote node a pre-downloaded independent rpm that is polled for by the bundled yum plugin (Go version 13.3). The command shown uses ORA as repository name and GCC as package name. Please replace as appropriate. Target node user should have passwordless sudo privilege.
 author: Go Team
 authorinfo: http://support.thoughtworks.com/categories/20002778-go-community-support
-moreinfo: http://www.thoughtworks.com/products/docs/go/current/help/yum_repository_poller.html#install
+moreinfo: http://www.go.cd/documentation/user/current/extension_points/yum_repository_poller.html#installing-rpms
 keywords: yum, install, rpm, upgrade, package
 -->
 <exec command="/bin/bash">

--- a/package/rpm/go-install-rpm-on-agent.xml
+++ b/package/rpm/go-install-rpm-on-agent.xml
@@ -3,7 +3,7 @@ name: Install rpm on agent
 description: Install on agent an rpm that is polled for by the bundled yum plugin (Go version 13.3). The command shown uses ORA as repository name and GCC as package name. Please replace as appropriate. /etc/yum.repos.d on the agent should contain repository definitions. go user should have passwordless sude privilege on the agent.
 author: Go Team
 authorinfo: http://support.thoughtworks.com/categories/20002778-go-community-support
-moreinfo: http://www.thoughtworks.com/products/docs/go/current/help/yum_repository_poller.html#install
+moreinfo: http://www.go.cd/documentation/user/current/extension_points/yum_repository_poller.html#installing-rpms
 keywords: yum, install, rpm
 -->
 <exec command="/bin/bash">

--- a/package/rpm/go-install-rpm-remote.xml
+++ b/package/rpm/go-install-rpm-remote.xml
@@ -3,7 +3,7 @@ name: Install rpm on remote node
 description: Install on remote node an rpm that is polled for by the bundled yum plugin (Go version 13.3). The command shown uses ORA as repository name and GCC as package name. Please replace as appropriate. /etc/yum.repos.d on the target node should contain repository definitions. Target node user should have passwordless sudo privilege.
 author: Go Team
 authorinfo: http://support.thoughtworks.com/categories/20002778-go-community-support
-moreinfo: http://www.thoughtworks.com/products/docs/go/current/help/yum_repository_poller.html#install
+moreinfo: http://www.go.cd/documentation/user/current/extension_points/yum_repository_poller.html#installing-rpms
 keywords: yum, install, rpm
 -->
 <exec command="/bin/bash">


### PR DESCRIPTION
- The links now point to gitbook http://www.go.cd/documentation/user/current.
